### PR TITLE
change the way spacebar is captured

### DIFF
--- a/src/scripts/youtube-pause-extension.js
+++ b/src/scripts/youtube-pause-extension.js
@@ -8,7 +8,7 @@
   a.onkeydown = responder;
   function responder(event) {
       // spacebar and not inside a the search or comments boxes
-      if (event.which == 32 && !((event.target.className.indexOf("search-term") !== -1) || (event.target.className.indexOf("yt-simplebox-text") !== -1))) {
+      if (event.which == 32 && ((event.target.className.indexOf("search-term") == -1) || (event.target.className.indexOf("yt-simplebox-text") == -1))) {
       var states = { 1: "playing", 2: "paused" };
       var p = window.document.getElementById("movie_player");
       var s = p && p.getPlayerState && states[p.getPlayerState()];

--- a/src/scripts/youtube-pause-extension.js
+++ b/src/scripts/youtube-pause-extension.js
@@ -3,22 +3,23 @@
 // Copyright (c) 2015 Nishanth Shanmugham
 
 
-;(function() {  
-  var a = document.getElementsByTagName("body")[0]; 
+;(function() {
+  var a = document.getElementsByTagName("body")[0];
   a.onkeydown = responder;
   console.log("ffsdsdf");
   function responder(event) {
-    if (event.which == 32 && ((event.target == document.body) || (event.target.className && event.target.classList.contains("yt-uix-button")))) { // spacebar and not inside a textarea, for instance
+      // spacebar and not inside a the search or comments boxes
+      if (event.which == 32 && !((event.target.className.indexOf("search-term") !== -1) || (event.target.className.indexOf("yt-simplebox-text") !== -1))) {
       var states = { 1: "playing", 2: "paused" };
       var p = window.document.getElementById("movie_player");
       var s = p && p.getPlayerState && states[p.getPlayerState()];
-      
+
       if (s && s === "playing") {
         p.pauseVideo();
       } else {
         p.playVideo();
       }
-      
+
       // playerState is automatically updated by an event elsewhere
 
       event.preventDefault();

--- a/src/scripts/youtube-pause-extension.js
+++ b/src/scripts/youtube-pause-extension.js
@@ -6,7 +6,6 @@
 ;(function() {
   var a = document.getElementsByTagName("body")[0];
   a.onkeydown = responder;
-  console.log("ffsdsdf");
   function responder(event) {
       // spacebar and not inside a the search or comments boxes
       if (event.which == 32 && !((event.target.className.indexOf("search-term") !== -1) || (event.target.className.indexOf("yt-simplebox-text") !== -1))) {


### PR DESCRIPTION
I noticed that in order for this extension to work, the user needs to click somewhere in the body of the page. This is due to it listening to events which occur in the body. Rather than listening to body events, I changed it so that it excludes events which happen in the search bar or comment box. Search bar and comment box are identified by className.

Not sure this is the best way to do it, but it works :sweat_smile:
